### PR TITLE
Bugfix: `protection.ra769_limits` should return proper quantities

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,14 @@
 0.25.8 (unreleased)
 =======================
 
+Bugfixes
+--------
+- `pycraf.protection.ra769_limits` now returns an `astropy.table.QTable`
+  instead of a `astropy.table.Table`. This ensures that in all
+  circumstances one retrieves proper `astropy.units.Quantity` objects from
+  the table. Previously, logarithmic units would not fully support this
+  (although this was a just bug in `astropy`, which is now fixed). [#8]
+
 0.25.7 (2018-11-24)
 =======================
 

--- a/docs/protection/index.rst
+++ b/docs/protection/index.rst
@@ -27,14 +27,14 @@ RA.769
 ------
 
 The function `~pycraf.protection.ra769_limits` returns a
-`~astropy.table.Table` object that resembles (Table 1 to 3) from
+`~astropy.table.QTable` object that resembles (Table 1 to 3) from
 `ITU-R Rec. RA.769 <https://www.itu.int/rec/R-REC-RA.769-2-200305-I/en>`_::
 
     >>> import astropy.units as u
     >>> from pycraf import protection
 
     >>> protection.ra769_limits(mode='continuum')
-    <Table length=21>
+    <QTable length=21>
     frequency bandwidth   T_A   ...     Slim_nu        Efield    Efield_norm
        MHz       MHz       K    ... dB(W / (Hz m2)) dB(uV2 / m2) dB(uV2 / m2)
      float64   float64  float64 ...     float64       float64      float64
@@ -56,7 +56,7 @@ The function `~pycraf.protection.ra769_limits` returns a
 For VLBI the returned table object looks a bit different::
 
     >>> protection.ra769_limits(mode='vlbi')
-    <Table length=21>
+    <QTable length=21>
     frequency   T_A     T_rx      Slim_nu
        MHz       K       K    dB(W / (Hz m2))
      float64  float64 float64     float64
@@ -87,7 +87,7 @@ integration time::
   >>> for itime in [15 * u.min, 1 * u.h, 2 * u.h, 5 * u.h, 10 * u.h]:
   ...     tab = protection.ra769_limits(mode='continuum', integ_time=itime)
   ...     # print values of footnote (1) of tables 1 and 2 in RA.769
-  ...     print('{:.1f} dB'.format(tab[7]['Plim'] - plim_2000s))
+  ...     print('{:.1f}'.format(tab[7]['Plim'] - plim_2000s))
   1.7 dB
   -1.3 dB
   -2.8 dB

--- a/notebooks/A01_case_study_fixed_link.ipynb
+++ b/notebooks/A01_case_study_fixed_link.ipynb
@@ -206,7 +206,7 @@
     }
    ],
    "source": [
-    "ras_power_lim = protection.ra769_limits()[11]['Plim'] * cnv.dB_W\n",
+    "ras_power_lim = protection.ra769_limits()[11]['Plim']\n",
     "print('RA.769 threshold: {:.1f}'.format(ras_power_lim))"
    ]
   },

--- a/notebooks/B01_wind_turbine_generic.ipynb
+++ b/notebooks/B01_wind_turbine_generic.ipynb
@@ -287,7 +287,7 @@
    ],
    "source": [
     "Plim = ra769_tab_db['Plim']\n",
-    "Plim.data"
+    "Plim.to(cnv.dB_W).value"
    ]
   },
   {
@@ -309,11 +309,11 @@
    "source": [
     "MCL_1 = (\n",
     "    cispr11_pow_lim_1.to(cnv.dB_W).value - \n",
-    "    ra769_tab_db['Plim'].data\n",
+    "    ra769_tab_db['Plim'].to(cnv.dB_W).value\n",
     "    ) * cnv.dB\n",
     "MCL_2 = (\n",
     "    cispr11_pow_lim_2.to(cnv.dB_W).value - \n",
-    "    ra769_tab_db['Plim'].data\n",
+    "    ra769_tab_db['Plim'].to(cnv.dB_W).value\n",
     "    ) * cnv.dB\n",
     "\n",
     "print(MCL_1)\n",

--- a/pycraf/protection/ra769.py
+++ b/pycraf/protection/ra769.py
@@ -267,7 +267,9 @@ def ra769_limits(mode='continuum', scale='dB', integ_time=2000. * apu.s):
             mode=mode, scale=scale, integ_time=integ_time,
             )
 
-    # table formatting doesn't seem to work for QTable, so we convert
+    # table formatting doesn't seem to work for QTable, so we temporarily
+    # convert to Table; interestingly, if we cast back to QTable afterwards
+    # the format specifier is still valid (gets converted to QuantityInfo...)
     tab = Table(qtab)
 
     for col in ['frequency', 'bandwidth', 'T_A', 'T_rx']:
@@ -292,4 +294,4 @@ def ra769_limits(mode='continuum', scale='dB', integ_time=2000. * apu.s):
         except KeyError:
             pass
 
-    return tab
+    return QTable(tab)

--- a/pycraf/protection/tests/test_protection.py
+++ b/pycraf/protection/tests/test_protection.py
@@ -230,8 +230,16 @@ def test_ra769_limits():
             (15, 'Slim_nu'),
             (20, 'Efield'),
             ]):
-        assert_allclose(cont_lims[row][col], CONT_LIMS_VALUES[idx], **TOL_KWARGS)
-        assert_allclose(cont_lims_dB[row][col], CONT_LIMS_DB_VALUES[idx])
+        colidx = COL_NAMES.index(col)
+        assert_quantity_allclose(
+            cont_lims[row][col],
+            CONT_LIMS_VALUES[idx] * COL_UNITS[colidx][-1],
+            rtol=1.e-6
+            )
+        assert_quantity_allclose(
+            cont_lims_dB[row][col],
+            CONT_LIMS_DB_VALUES[idx] * COL_UNITS_DB[colidx][-1]
+            )
 
     for idx, (row, col) in enumerate([
             (0, 'T_rms'),
@@ -240,16 +248,32 @@ def test_ra769_limits():
             (9, 'Slim_nu'),
             (12, 'Efield'),
             ]):
-        assert_allclose(spec_lims[row][col], SPEC_LIMS_VALUES[idx], **TOL_KWARGS)
-        assert_allclose(spec_lims_dB[row][col], SPEC_LIMS_DB_VALUES[idx])
+        colidx = COL_NAMES.index(col)
+        assert_quantity_allclose(
+            spec_lims[row][col],
+            SPEC_LIMS_VALUES[idx] * COL_UNITS[colidx][0],
+            rtol=1.e-6
+            )
+        assert_quantity_allclose(
+            spec_lims_dB[row][col],
+            SPEC_LIMS_DB_VALUES[idx] * COL_UNITS_DB[colidx][0]
+            )
 
     for idx, (row, col) in enumerate([
             (5, 'Slim_nu'),
             (10, 'Slim_nu'),
             (15, 'Slim_nu'),
             ]):
-        assert_allclose(vlbi_lims[row][col], VLBI_LIMS_VALUES[idx], **TOL_KWARGS)
-        assert_allclose(vlbi_lims_dB[row][col], VLBI_LIMS_DB_VALUES[idx])
+        colidx = COL_NAMES.index(col)
+        assert_quantity_allclose(
+            vlbi_lims[row][col],
+            VLBI_LIMS_VALUES[idx] * COL_UNITS[colidx][0],
+            rtol=1.e-6
+            )
+        assert_quantity_allclose(
+            vlbi_lims_dB[row][col],
+            VLBI_LIMS_DB_VALUES[idx] * COL_UNITS_DB[colidx][0]
+            )
 
     for colname, colunits in zip(COL_NAMES, COL_UNITS):
         assert cont_lims.columns[colname].unit in colunits


### PR DESCRIPTION
Fix #6.

`pycraf.protection.ra769_limits` now returns an `astropy.table.QTable`   instead of a `astropy.table.Table`. This ensures that in all circumstances one retrieves proper `astropy.units.Quantity` objects from the table. Previously, logarithmic units would not fully support this (although this was a just bug in `astropy`, which is now fixed).