### PR TITLE
add "return_raw" option to pathprof.gis.regrid_from_geotiff

### DIFF
--- a/pycraf/pathprof/gis.py
+++ b/pycraf/pathprof/gis.py
@@ -233,7 +233,7 @@ def wgs84_to_geotiff_pixels(geotiff, lons, lats):
     strip_input_units=False,
     output_unit=None,
     )
-def regrid_from_geotiff(geotiff, lons, lats, band=1):
+def regrid_from_geotiff(geotiff, lons, lats, band=1, return_raw=False):
     '''
     Retrieve interpolated GeoTiff raster values for given WGS84 coordinates
     (longitude, latitude).
@@ -254,6 +254,10 @@ def regrid_from_geotiff(geotiff, lons, lats, band=1):
         Geographic longitudes/latitudes (WGS84) [deg]
     band : int, Optional (default: 1)
         The GeoTiff band to use.
+    return_raw : Boolean, Optional (default: False)
+        Also return the original data (in the same window). This may be
+        useful if the normalization of the data is important (e.g., for
+        a population map rather than a population density map).
 
     Returns
     -------
@@ -262,6 +266,10 @@ def regrid_from_geotiff(geotiff, lons, lats, band=1):
         latitude positions. If the input GeoTiff has more than one band and
         you need to regrid several of the bands, please run the function
         repeatedly, specifying the band parameter.
+    geo_data_raw : `~numpy.ndarray`
+        Only returned when `return_raw == True`
+        Original/raw values of the input raster map in the the same window
+        that was queried with this function.
 
     Notes
     -----
@@ -305,4 +313,10 @@ def regrid_from_geotiff(geotiff, lons, lats, band=1):
 
     geo_data_regridded = geo_interp((geo_x - col_off, geo_y - row_off))
 
-    return geo_data_regridded.astype(geo_data.dtype, copy=False)
+    if return_raw:
+        return (
+          geo_data_regridded.astype(geo_data.dtype, copy=False),
+          geo_data[5:-5, 5:-5]
+          )
+    else:
+        return geo_data_regridded.astype(geo_data.dtype, copy=False)

--- a/pycraf/pathprof/tests/test_gis.py
+++ b/pycraf/pathprof/tests/test_gis.py
@@ -161,6 +161,31 @@ def test_regrid_from_geotiff():
                 ),
             )
 
+        geodata_regridded, geodata_raw = tfunc(lons, lats, return_raw=True)
+
+        np.testing.assert_equal(
+            geodata_regridded, np.array([
+                [211, 311, 311, 231, 231],
+                [231, 311, 112, 312, 312],
+                [312, 231, 112, 312, 312],
+                [211, 312, 312, 211, 231],
+                [311, 211, 311, 312, 312],
+                ],
+                dtype=np.int16,
+                ),
+            )
+        # print(geodata_raw[::80, ::80])
+        np.testing.assert_equal(
+            geodata_raw[::80, ::80], np.array([
+                [211, 312, 211, 211, 311],
+                [311, 312, 312, 231, 211],
+                [231, 312, 231, 311, 311],
+                [311, 231, 311, 312, 312],
+                ],
+                dtype=np.int16,
+                ),
+            )
+
 
 @skip_rio
 def test_regrid_from_geotiff_degenerated():


### PR DESCRIPTION
This can be useful if one needs the original data (in the same bounding box) for applying some kind of normalization or sanity checking.